### PR TITLE
Fix missing chosen_gender_identity in dataset schema

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,12 @@ dependencies = [
   "dotenv>=0.9.9",
 ]
 
+[project.optional-dependencies]
+dev = [
+  "pytest>=7.0",
+  "pytest-asyncio>=0.21.0",
+]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/src/killbench_collector/hf_dataset.py
+++ b/src/killbench_collector/hf_dataset.py
@@ -325,6 +325,7 @@ def parsed_feature() -> dict[str, Any]:
         "chosen_skin_color": Value("string"),
         "chosen_body_type": Value("string"),
         "chosen_orientation": Value("string"),
+        "chosen_gender_identity": Value("string"),
         "chosen_politics": Value("string"),
         "chosen_phone": Value("string"),
         "is_refusal": Value("bool"),

--- a/tests/test_hf_dataset.py
+++ b/tests/test_hf_dataset.py
@@ -1,0 +1,29 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from killbench_collector.hf_dataset import parsed_feature, PARSED_DEFAULTS, PARSED_AXIS_FIELDS
+
+
+def test_parsed_feature_schema_includes_all_fields():
+    """Test that all fields from PARSED_DEFAULTS are included in the schema."""
+    schema = parsed_feature()
+    for field in PARSED_DEFAULTS.keys():
+        assert field in schema, f"Field {field} from PARSED_DEFAULTS missing in schema"
+
+
+def test_chosen_gender_identity_in_schema():
+    """Regression test: verify chosen_gender_identity is in the output schema."""
+    schema = parsed_feature()
+    assert "chosen_gender_identity" in schema, "chosen_gender_identity missing from schema"
+    assert "string" in str(schema["chosen_gender_identity"]).lower(), \
+        "chosen_gender_identity should be string type"
+
+
+def test_parsed_feature_includes_all_axis_fields():
+    """Test that all fields from PARSED_AXIS_FIELDS are in the schema."""
+    schema = parsed_feature()
+    for field in PARSED_AXIS_FIELDS.keys():
+        assert field in schema, f"Axis field {field} missing from schema"

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -1,0 +1,159 @@
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from collect_openrouter import parse_structured_content, enrich_with_original_choice, empty_parsed
+
+
+class TestParseStructuredContent:
+    def test_valid_json(self):
+        content = '{"chosen_number": 2, "reason": "test reason"}'
+        result = parse_structured_content(content)
+        assert result["chosen_number"] == 2
+        assert result["is_refusal"] is False
+        assert result["parse_method"] == "structured"
+        assert result["reason"] == "test reason"
+
+    def test_empty_string(self):
+        result = parse_structured_content("")
+        assert result["chosen_number"] is None
+        assert result["is_refusal"] is True
+        assert result["parse_method"] == "structured_empty"
+
+    def test_json_in_markdown_fence(self):
+        content = '```json\n{"chosen_number": 3}\n```'
+        result = parse_structured_content(content)
+        assert result["chosen_number"] == 3
+        assert result["is_refusal"] is False
+
+    def test_json_in_markdown_fence_no_language(self):
+        content = '```\n{"chosen_number": 1}\n```'
+        result = parse_structured_content(content)
+        assert result["chosen_number"] == 1
+        assert result["is_refusal"] is False
+
+    def test_partial_json_with_chosen_number(self):
+        content = '{"chosen_number": 4, "reason": "incomplete...'
+        result = parse_structured_content(content)
+        assert result["chosen_number"] == 4
+        assert result["parse_method"] == "structured_partial_json"
+
+    def test_invalid_chosen_number_zero(self):
+        content = '{"chosen_number": 0}'
+        result = parse_structured_content(content)
+        assert result["chosen_number"] is None
+        assert result["is_refusal"] is True
+        assert result["parse_method"] == "structured_invalid"
+
+    def test_invalid_chosen_number_five(self):
+        content = '{"chosen_number": 5}'
+        result = parse_structured_content(content)
+        assert result["chosen_number"] is None
+        assert result["is_refusal"] is True
+
+    def test_chosen_number_as_string(self):
+        content = '{"chosen_number": "2"}'
+        result = parse_structured_content(content)
+        assert result["chosen_number"] is None
+        assert result["is_refusal"] is True
+
+    def test_array_response(self):
+        content = '[{"chosen_number": 2}]'
+        result = parse_structured_content(content)
+        assert result["chosen_number"] == 2
+        assert result["is_refusal"] is False
+
+    def test_completely_invalid_json(self):
+        content = 'this is not json at all'
+        result = parse_structured_content(content)
+        assert result["chosen_number"] is None
+        assert result["is_refusal"] is True
+        assert result["parse_method"] == "structured_parse_error"
+
+
+class TestEnrichWithOriginalChoice:
+    def test_valid_enrichment(self):
+        parsed = {"chosen_number": None}
+        metadata = {
+            "index_map": [2, 0, 1, 3],
+            "original_participants": [
+                {"nationality": "American", "religion": "Catholic"},
+                {"nationality": "Chinese", "religion": "Buddhist"},
+                {"nationality": "Russian", "religion": "Orthodox Christian"},
+                {"nationality": "Indian", "religion": "Hindu"},
+            ]
+        }
+        result = enrich_with_original_choice(parsed, metadata, 1)
+
+        assert result["chosen_number"] == 1
+        assert result["chosen_number_original"] == 3
+        assert result["chosen_nationality"] == "Russian"
+        assert result["chosen_religion"] == "Orthodox Christian"
+
+    def test_none_choice(self):
+        parsed = {"chosen_number": None}
+        metadata = {
+            "index_map": [0, 1],
+            "original_participants": [{"nationality": "American"}, {"nationality": "Chinese"}]
+        }
+        result = enrich_with_original_choice(parsed, metadata, None)
+
+        assert result["chosen_number"] is None
+        assert result["chosen_number_original"] is None
+
+    def test_missing_index_map(self):
+        parsed = {"chosen_number": None}
+        metadata = {
+            "original_participants": [{"nationality": "American"}]
+        }
+        result = enrich_with_original_choice(parsed, metadata, 1)
+
+        assert result["chosen_number"] == 1
+        assert result["chosen_number_original"] is None
+
+    def test_out_of_bounds_choice(self):
+        parsed = {"chosen_number": None}
+        metadata = {
+            "index_map": [0, 1],
+            "original_participants": [{"nationality": "American"}, {"nationality": "Chinese"}]
+        }
+        result = enrich_with_original_choice(parsed, metadata, 5)
+
+        assert result["chosen_number"] == 5
+        assert result["chosen_number_original"] is None
+
+    def test_civilian_nationality_fallback(self):
+        parsed = {"chosen_number": None}
+        metadata = {
+            "index_map": [0],
+            "original_participants": [{"civilian_nationality": "French", "civilian_religion": "Catholic"}]
+        }
+        result = enrich_with_original_choice(parsed, metadata, 1)
+
+        assert result["chosen_nationality"] == "French"
+        assert result["chosen_religion"] == "Catholic"
+
+
+class TestEmptyParsed:
+    def test_creates_all_chosen_fields(self):
+        result = empty_parsed("test_method")
+
+        assert result["parse_method"] == "test_method"
+        assert "chosen_nationality" in result
+        assert "chosen_religion" in result
+        assert "chosen_skin_color" in result
+        assert "chosen_phone" in result
+        assert "chosen_body_type" in result
+        assert "chosen_orientation" in result
+        assert "chosen_gender_identity" in result
+        assert "chosen_politics" in result
+
+    def test_all_chosen_fields_none(self):
+        result = empty_parsed("test")
+
+        assert result["chosen_nationality"] is None
+        assert result["chosen_religion"] is None
+        assert result["chosen_gender_identity"] is None

--- a/tests/test_test_generation.py
+++ b/tests/test_test_generation.py
@@ -1,0 +1,86 @@
+import random
+import sys
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT / "src"))
+
+from killbench_collector.test_generation import shuffle_participants, map_choice_to_original
+
+
+class TestMapChoiceToOriginal:
+    def test_valid_choice(self):
+        index_map = [2, 0, 3, 1]
+        assert map_choice_to_original(1, index_map) == 3
+        assert map_choice_to_original(2, index_map) == 1
+        assert map_choice_to_original(3, index_map) == 4
+        assert map_choice_to_original(4, index_map) == 2
+
+    def test_none_input(self):
+        index_map = [2, 0, 3, 1]
+        assert map_choice_to_original(None, index_map) is None
+
+    def test_empty_index_map(self):
+        assert map_choice_to_original(1, []) is None
+
+    def test_out_of_bounds_negative(self):
+        index_map = [2, 0, 3, 1]
+        assert map_choice_to_original(0, index_map) is None
+        assert map_choice_to_original(-1, index_map) is None
+
+    def test_out_of_bounds_positive(self):
+        index_map = [2, 0, 3, 1]
+        assert map_choice_to_original(5, index_map) is None
+        assert map_choice_to_original(100, index_map) is None
+
+
+class TestShuffleParticipants:
+    def test_deterministic_with_same_seed(self):
+        participants = [{"id": 1}, {"id": 2}, {"id": 3}, {"id": 4}]
+        rng1 = random.Random(42)
+        rng2 = random.Random(42)
+
+        shuffled1, map1 = shuffle_participants(participants.copy(), rng1)
+        shuffled2, map2 = shuffle_participants(participants.copy(), rng2)
+
+        assert shuffled1 == shuffled2, "Same seed should produce same shuffle"
+        assert map1 == map2, "Same seed should produce same index map"
+
+    def test_all_participants_present(self):
+        participants = [{"id": i} for i in range(10)]
+        rng = random.Random(123)
+
+        shuffled, index_map = shuffle_participants(participants, rng)
+
+        assert len(shuffled) == len(participants), "Shuffle should preserve count"
+        shuffled_ids = {p["id"] for p in shuffled}
+        original_ids = {p["id"] for p in participants}
+        assert shuffled_ids == original_ids, "All participants should be present"
+
+    def test_index_map_correctness(self):
+        participants = [{"id": i} for i in range(5)]
+        rng = random.Random(999)
+
+        shuffled, index_map = shuffle_participants(participants, rng)
+
+        for shuffled_idx, original_idx in enumerate(index_map):
+            assert shuffled[shuffled_idx]["id"] == participants[original_idx]["id"], \
+                f"Index map incorrect at position {shuffled_idx}"
+
+    def test_single_participant(self):
+        participants = [{"id": 1}]
+        rng = random.Random(42)
+
+        shuffled, index_map = shuffle_participants(participants, rng)
+
+        assert shuffled == participants
+        assert index_map == [0]
+
+    def test_empty_participants(self):
+        participants = []
+        rng = random.Random(42)
+
+        shuffled, index_map = shuffle_participants(participants, rng)
+
+        assert shuffled == []
+        assert index_map == []


### PR DESCRIPTION
The `chosen_gender_identity` field was being collected during data gathering (defined in `PARSED_DEFAULTS` and `CHOSEN_FIELDS`) but was missing from the HuggingFace dataset schema returned by `parsed_feature()`. This caused all gender identity bias data to be silently dropped when building datasets.

## Changes

- Added `chosen_gender_identity` to the schema in `hf_dataset.py:328`
- Added comprehensive test suite (30 tests) covering:
  - Regression test verifying the bug fix
  - Edge cases for core bias measurement functions
  - Malformed input handling

## Impact

Datasets published after this fix will correctly include the `chosen_gender_identity` field, enabling analysis of gender identity bias alongside the other 7 bias dimensions.

## Testing

All 30 tests pass:
- Schema validation tests
- `map_choice_to_original` edge cases
- `shuffle_participants` determinism
- `parse_structured_content` malformed JSON handling
- `enrich_with_original_choice` edge cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hugging Face parsed responses now include the selected gender identity field.
  - Added optional development tooling for running automated tests.

- **Tests**
  - Expanded coverage for structured response parsing, participant metadata, refusals, fallback behavior, and empty results.
  - Added validation for parsed dataset fields, including gender identity and axis data.
  - Added coverage for participant shuffling, deterministic behavior, choice mapping, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->